### PR TITLE
Fix invalid image type assertion

### DIFF
--- a/API/picapi.py
+++ b/API/picapi.py
@@ -181,7 +181,7 @@ def get_picture(filename: str):
                     background_color = bg_color,
                     ) 
     
-    assert type(image is Image), 'Image is not type PIL/Image' 
+    assert isinstance(image, Image.Image), 'Image is not type PIL.Image'
     image.save(img_io, format=img_format)
     img_io.seek(0)
     return send_file(img_io, mimetype=f'image/{img_format.lower()}')


### PR DESCRIPTION
## Summary
- fix image type assertion for return data

## Testing
- `python3 -m py_compile API/picapi.py API/ImageTransformer.py API/ImageBucket.py API/RSAencryption.py API/SQLiteInterface.py`


------
https://chatgpt.com/codex/tasks/task_e_6852695095a483268c71de9ab334948c